### PR TITLE
Support serheiti and number lookups when they are in vidsk

### DIFF
--- a/tests/test_iceaddr.py
+++ b/tests/test_iceaddr.py
@@ -64,10 +64,24 @@ def test_address_lookup():
     assert len(iceaddr_lookup("Grundarstíg", limit=2)) == 2
 
 
+def test_address_lookup_matches_number_range_and_no_number():
+    results = iceaddr_lookup("Vesturgata", number=6, placename="Reykjavík")
+    assert results
+    assert results[0]["vidsk"] == "6-8"
+    assert results[0]["husnr"] is None
+
+
+def test_address_lookup_can_find_places_of_interest():
+    results = iceaddr_lookup("Harpa", postcode=101)
+    assert results
+    assert results[0]["heiti_nf"] == "Austurbakki"
+    assert results[0]["husnr"]
+
+
 def test_address_lookup_does_not_need_letter():
     assert iceaddr_lookup("Laugavegur", number=151)
-    assert iceaddr_lookup("Laugavegur", number=151, letter='r')
-    assert not iceaddr_lookup("Laugavegur", number=151, letter='e')
+    assert iceaddr_lookup("Laugavegur", number=151, letter="r")
+    assert not iceaddr_lookup("Laugavegur", number=151, letter="e")
 
 
 def test_address_suggestions():


### PR DESCRIPTION
I have noticed that there are hnitnums where:

1. there is no `husnr` but `vidsk` has a house number range (ex. "6-8")
2. there is a `husnr` and `vidsk` has a house number range where the `husnr` is the first number in the range

(PS: Looks like we were doing similar refactoring for variable names.)

Note: This does not support lookup for strings with ranges. You have to have the integer number for start of the range. It works even if there is a range in `vidsk` but no `husnr`.

Here are examples of address matches from input strings that were improved on my end. Note that I don't want to match when I don't have house numbers in the input, unless it's under serheiti (like Harpa, churches and other places of interest).

<img width="543" alt="Messages Image(1419703205)" src="https://user-images.githubusercontent.com/701/92301950-80c7ea80-ef57-11ea-8705-c24e32ae96d4.png">
