### PR TITLE
Add heinum to address data

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ offline. The package is useful for geocoding and reverse geocoding of Icelandic
 addresses and placenames, as well as validating addresses and postcodes.
 No external dependencies are required.
 
+For joining address results with other Icelandic public datasets, prefer
+the `heinum` field when the other dataset identifies the address itself.
+`heinum` is the address number (`staðfanganúmer`, also called `HEINUM` in
+Staðfangaskrá). The `hnitnum` field identifies the address point coordinate.
+
 ## Installation
 
 The latest version of `iceaddr` is available via [PyPI](https://pypi.org/project/iceaddr/).
@@ -43,13 +48,15 @@ pip install iceaddr
 >>> pprint(a)
 [{'bokst': '',
   'byggd': 1,
+  'heinum': 1001754,
   'heiti_nf': 'Austurstræti',
   'heiti_tgf': 'Austurstræti',
   'hnitnum': 10083839,
   'husnr': 14,
   'landnr': 100852,
-  'lat_wgs84': 64.147529217656,
-  'long_wgs84': -21.9389394651385,
+  'lat_wgs84': 64.14752922,
+  'long_wgs84': -21.93893947,
+  'lysing': 'Miðborg',
   'postnr': 101,
   'serheiti': '',
   'stadur_nf': 'Reykjavík',
@@ -58,8 +65,10 @@ pip install iceaddr
   'svaedi_tgf': 'Höfuðborgarsvæðinu',
   'svfheiti': 'Reykjavíkurborg',
   'svfnr': 0,
-  'tegund': 'Þéttbýli',
+  'tegund': 'Stærra dreifbýli',
   'vidsk': ''}]
+>>> a[0]["heinum"]
+1001754
 ```
 
 ### Look up address with placename
@@ -70,13 +79,15 @@ pip install iceaddr
 >>> pprint(a)
 [{'bokst': '',
   'byggd': 1,
+  'heinum': 1020228,
   'heiti_nf': 'Öldugata',
   'heiti_tgf': 'Öldugötu',
   'hnitnum': 10017023,
   'husnr': 4,
   'landnr': 100570,
-  'lat_wgs84': 64.1484874806941,
-  'long_wgs84': -21.9452072913341,
+  'lat_wgs84': 64.14848748,
+  'long_wgs84': -21.94520729,
+  'lysing': 'Miðborg',
   'postnr': 101,
   'serheiti': '',
   'stadur_nf': 'Reykjavík',
@@ -85,8 +96,10 @@ pip install iceaddr
   'svaedi_tgf': 'Höfuðborgarsvæðinu',
   'svfheiti': 'Reykjavíkurborg',
   'svfnr': 0,
-  'tegund': 'Þéttbýli',
+  'tegund': 'Stærra dreifbýli',
   'vidsk': ''}]
+>>> a[0]["heinum"]
+1020228
 ```
 
 Street and place names can be provided in either nominative (nf.) or
@@ -137,13 +150,14 @@ a list of the nearest addresses in the database:
 | ------------- |---------------------------------------------------------|
 | bokst         | House letter, e.g. "A", "b"                             |
 | byggd         | Byggðarnúmer in municipality                            |
+| heinum        | Staðfanganúmer/heitinúmer, unique ID for the address    |
 | heiti_nf      | Street name (nominative case, nf.), e.g. 'Öldugata'     |
 | heiti_tgf     | Street name (dative case, þgf.), e.g. 'Öldugötu'        |
-| hnitnum       | Hnitnúmer staðfangahnits                                |
+| hnitnum       | Unique address point coordinate ID                      |
 | husnr         | House number                                            |
 | landnr        | Hlaupandi sex stafa auðkennisnúmer í landeignaskrá HMS  |
-| lat_wgs84     | Latitude (WGS84 coordinates)                            |
-| long_wgs84    | Longitude (WGS84 coordinates)                           |
+| lat_wgs84     | Latitude (WGS84), for geospatial lookup/display         |
+| long_wgs84    | Longitude (WGS84), for geospatial lookup/display        |
 | postnr        | Postcode (e.g. 101)                                     |
 | serheiti      | Special name                                            |
 | stadur_nf     | Placename (nominative case), e.g. 'Selfoss'             |

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ No external dependencies are required.
 
 For joining address results with other Icelandic public datasets, prefer
 the `heinum` field when the other dataset identifies the address itself.
-`heinum` is the address number (`staðfanganúmer`, also called `HEINUM` in
-Staðfangaskrá). The `hnitnum` field identifies the address point coordinate.
+`heinum` is the address number (Icelandic: `staðfanganúmer` or
+`heitinúmer`; upstream field name: `HEINUM`). The `hnitnum` field identifies
+the address point coordinate.
 
 ## Installation
 
@@ -149,13 +150,13 @@ a list of the nearest addresses in the database:
 | Key           | Value description                                       |
 | ------------- |---------------------------------------------------------|
 | bokst         | House letter, e.g. "A", "b"                             |
-| byggd         | Byggðarnúmer in municipality                            |
-| heinum        | Staðfanganúmer/heitinúmer, unique ID for the address    |
+| byggd         | Settlement number within municipality                   |
+| heinum        | Address number, unique ID for the address itself        |
 | heiti_nf      | Street name (nominative case, nf.), e.g. 'Öldugata'     |
 | heiti_tgf     | Street name (dative case, þgf.), e.g. 'Öldugötu'        |
 | hnitnum       | Unique address point coordinate ID                      |
 | husnr         | House number                                            |
-| landnr        | Hlaupandi sex stafa auðkennisnúmer í landeignaskrá HMS  |
+| landnr        | Land registry number                                    |
 | lat_wgs84     | Latitude (WGS84), for geospatial lookup/display         |
 | long_wgs84    | Longitude (WGS84), for geospatial lookup/display        |
 | postnr        | Postcode (e.g. 101)                                     |

--- a/build_db.py
+++ b/build_db.py
@@ -42,6 +42,7 @@ COLS = [
     "svfnr",
     "byggd",
     "landnr",
+    "heinum",
     "postnr",
     "heiti_nf",
     "heiti_tgf",
@@ -64,6 +65,7 @@ def create_db(path: str) -> sqlite3.Connection:
         svfnr INTEGER,
         byggd INTEGER,
         landnr INTEGER,
+        heinum INTEGER,
         postnr INTEGER,
         heiti_nf TEXT,
         heiti_tgf TEXT,
@@ -172,7 +174,7 @@ def insert_address_entry(e: dict[Any, Any], conn: sqlite3.Connection) -> None:
         qargs = [e[c.upper()] for c in COLS]
         # print(qargs)
         c = conn.cursor()
-        c.execute("INSERT INTO stadfong VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)", qargs)
+        c.execute("INSERT INTO stadfong VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)", qargs)
     except Exception as exc:
         print(exc)
 

--- a/tests/test_iceaddr.py
+++ b/tests/test_iceaddr.py
@@ -50,6 +50,7 @@ def test_address_lookup():
     for a in ADDR_TO_POSTCODE:
         res = iceaddr_lookup(a[0], number=a[1], placename=a[2])
         assert res[0]["postnr"] == a[3]
+        assert isinstance(res[0]["heinum"], int)
 
     res = iceaddr_lookup("Brattagata", number=4, letter="b")
     assert res[0]["postnr"] == 310
@@ -102,6 +103,7 @@ def test_address_suggestions():
     """Test address suggestions for natural language search strings."""
     res = iceaddr_suggest("Öldugötu 4, 101")
     assert res[0]["heiti_nf"] == "Öldugata"
+    assert res[0]["heinum"] == 1020228
     assert res[0]["husnr"] == 4
     assert res[0]["stadur_nf"] == "Reykjavík"
     assert res[0]["postnr"] == 101
@@ -241,6 +243,7 @@ def test_nearest_addr():
     addr = nearest_addr(FISKISLOD_31_COORDS[0], FISKISLOD_31_COORDS[1])
     assert len(addr) == 1
     assert addr[0]["heiti_nf"] == "Fiskislóð"
+    assert isinstance(addr[0]["heinum"], int)
     assert addr[0]["postnr"] == POSTCODE_101
     assert addr[0]["svaedi_nf"] == "Höfuðborgarsvæðið"
 


### PR DESCRIPTION
- Add upstream `HEINUM`/`heinum` to the packaged address database.
- Include `heinum` when rebuilding `stadfong` from Staðfangaskrá.
- Document the distinction between `heinum` as the address identifier and `hnitnum` as the address-point coordinate identifier.
- Add regression coverage that lookup, suggest, and nearest-address results expose `heinum`.

Fixes https://github.com/sveinbjornt/iceaddr/issues/15.

`HEINUM` is present in the upstream Staðfangaskrá CSV but was parsed and then dropped during import. That made it harder to join `iceaddr` results with HMS and other public datasets that identify the address itself by `staðfanganúmer`/`heitinúmer`.


## HMS sanity check

Checked the live HMS `Stadfangaskra.csv` source for `Flókagata 43`. HMS has exactly one matching row, and it matches the updated `iceaddr` result:

```text
HNITNUM:       10010471
HEINUM:        1005403
LANDNR:        103267
POSTNR:        105
HEITI_NF:      Flókagata
HEITI_TGF:     Flókagötu
HUSNR:         43
N_HNIT_WGS84:  64.13839168
E_HNIT_WGS84: -21.91052426
```

This confirms the new `heinum` field is coming from HMS and is exposed correctly by the package.
